### PR TITLE
adds support for MySQL5.7 global cluster

### DIFF
--- a/aws/resource_aws_rds_global_cluster.go
+++ b/aws/resource_aws_rds_global_cluster.go
@@ -44,6 +44,7 @@ func resourceAwsRDSGlobalCluster() *schema.Resource {
 				Default:  "aurora",
 				ValidateFunc: validation.StringInSlice([]string{
 					"aurora",
+					"aurora-mysql",
 				}, false),
 			},
 			"engine_version": {

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 *  `global_cluster_identifier` - (Required, Forces new resources) The global cluster identifier.
 * `database_name` - (Optional, Forces new resources) Name for an automatically created database on cluster creation.
 * `deletion_protection` - (Optional) If the Global Cluster should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
-* `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Valid values: `aurora`. Defaults to `aurora`.
+* `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Valid values: `aurora`(5.6) and `aurora-mysql`(5.7). Defaults to `aurora`.
 * `engine_version` - (Optional, Forces new resources) Engine version of the Aurora global database.
 * `storage_encrypted` - (Optional, Forces new resources) Specifies whether the DB cluster is encrypted. The default is `false`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds support for MySQL 5.7 compatible Aurora Global Clusters. [Aurora Global Database is Now Supported on Amazon Aurora MySQL 5.7](https://aws.amazon.com/about-aws/whats-new/2019/11/aurora-global-database-is-now-supported-amazon-aurora-mysql-57/)
```
